### PR TITLE
fix: Ubuntu 21.04 release name

### DIFF
--- a/after-effects
+++ b/after-effects
@@ -497,7 +497,7 @@ function _fix_ubuntu_derivatives() {
   hirsute)
     readonly enable_ppa="true"
     readonly distro_name="ubuntu"
-    log_notice "Release is Ubuntu 20.10 Groovy Gorilla"
+    log_notice "Release is Ubuntu 21.04 Hirsute Hippo"
     ;;
   # Upcoming Ubuntu release
   impish)


### PR DESCRIPTION
Stumbled upon it while browsing the source code...

Cheers!